### PR TITLE
fix: clear command: added linux support

### DIFF
--- a/lib.h
+++ b/lib.h
@@ -1,3 +1,15 @@
+#if defined(_WIN32)
+    #define CLEAR_COMMAND "cls"
+#elif defined(_WIN64)
+    #define CLEAR_COMMAND "cls"
+#elif defined(__CYGWIN__) && !defined(_WIN32)
+    #define CLEAR_COMMAND "cls"
+#elif defined(__linux__)
+    #define CLEAR_COMMAND "clear"
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define CLEAR_COMMAND "clear"
+#endif
+
 #ifndef LIB_H
 #define LIB_H
 

--- a/main.c
+++ b/main.c
@@ -22,26 +22,26 @@ int main() {
 
         switch (choix) {
             case 1:
-                system("cls");
+                system(CLEAR_COMMAND);
                 nb1 = rand() % 73 + 1;
                 ajouter_identifiants(keyUser, keyMachine, nb1);
                 break;
             case 2:
-                system("cls");
+                system(CLEAR_COMMAND);
                 modifier_identifiants(keyUser, keyMachine);
                 break;
             case 3:
-                system("cls");
+                system(CLEAR_COMMAND);
                 supprimer_identifiants(keyUser, keyMachine);
                 break;
             case 4:
-                system("cls");
+                system(CLEAR_COMMAND);
                 visualiser_identifiants(keyUser, keyMachine);
                 break;
             case 5:
                 break;
             default:
-                system("cls");
+                system(CLEAR_COMMAND);
         }
     } while (choix != 5);
 


### PR DESCRIPTION
Ajout de directives de préprocesseur pour le support des systèmes non Windows. La commande `cls` n'est pas nativement prise en charge sous Linux (Mint 21.2 Cinnamon), l'ajout de ces directives permet de switch automatiquement entre la commande Windows et Linux (`clear`).
Voir [cette page](https://sourceforge.net/p/predef/wiki/OperatingSystems/).